### PR TITLE
Update waf.cve-2021-44228-log4j-exploitation-attempt.yaml

### DIFF
--- a/workshop/alerts/waf.cve-2021-44228-log4j-exploitation-attempt.yaml
+++ b/workshop/alerts/waf.cve-2021-44228-log4j-exploitation-attempt.yaml
@@ -9,6 +9,6 @@ spec:
   severity: 100
   dataSet: waf
   period: 1m
-  lookback: 1h
+  lookback: 1m
   query: '"rule_info" IN {"*1005*"}'
   aggregateBy: [rule_info, method, path, destination.hostname, destination.ip, source.hostname, source.ip]


### PR DESCRIPTION
changed `lookback: 1h` to `lookback: 1m` as looking back for an hour with 1m period generates lots of the same alerts.