### PR TITLE
fix link to system requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ We will guide you through the following Calico Cloud use cases:
 
 ## Workshop Prerequisites
 
-- k8s cluster compliant with [system requirements](https://docs.calicocloud.io/get-started/requirements/system-requirements)
+- k8s cluster compliant with [system requirements](https://docs.tigera.io/calico-cloud/get-started/connect/requirements/system-requirements)
 - `Docker`
 - `curl`
 - `kubectl`


### PR DESCRIPTION
This links gives a 404
https://docs.tigera.io/calico-cloud/get-started/requirements/system-requirements

This links provides the required information
https://docs.tigera.io/calico-cloud/get-started/connect/requirements/system-requirements